### PR TITLE
Add Pointer() return string as pointer

### DIFF
--- a/pointer.go
+++ b/pointer.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package xstrings
+
+// Pointer returns string typed s as pointer.
+func Pointer[T ~string](s T) *T {
+	return &s
+}

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022, Geert JM Vanderkelen
+
+package xstrings
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/geertjanvdk/xkit/xt"
+)
+
+type stringTyped string
+
+func TestPointer(t *testing.T) {
+	t.Run("string as pointer", func(t *testing.T) {
+		s := "a string"
+		have := Pointer(s)
+		rv := reflect.ValueOf(have)
+		xt.Eq(t, reflect.Pointer, rv.Kind())
+	})
+
+	t.Run("string type as pointer", func(t *testing.T) {
+		var s stringTyped = "a string"
+		have := Pointer(s)
+		rv := reflect.ValueOf(have)
+		xt.Eq(t, reflect.Pointer, rv.Kind())
+	})
+}


### PR DESCRIPTION
We add the `Pointer()` function which takes a string, and returns
a pointer value. Silly little function saves lines!